### PR TITLE
Wrong reference for Python OAuth2 client

### DIFF
--- a/2/index.php
+++ b/2/index.php
@@ -43,7 +43,7 @@ $page_meta_description = "Resources and information related to the OAuth 2.0 pro
 				<li><a href="http://github.com/lukeredpath/LROAuth2Client">iPhone and iPad</a></li>
 				<li><a href="http://github.com/intridea/oauth2">Ruby Gem</a></li>
 				<li><a href="http://github.com/aflatter/oauth2-ruby">Ruby</a></li>
-				<li><a href="http://github.com/dgouldin/python-oauth2">Python</a></li>
+				<li><a href="http://github.com/litl/rauth">Python</a></li>
 			</ul>
 
     </div>


### PR DESCRIPTION
Please change the hyperlink referencing OAuth2 client library for Python like as I pushed.

Regarding to http://oauth.net/2/, a hyperlink to OAuth2 client for python is pointing to python-oauth2 a.k.a. oauth2 on PyPI (Python Package Index) which is totally not supporting OAuth2 but just has a name "oauth2" as it is using 'urllib2' for HTTP request.

A few OAuth2 client libraries for Python available on PyPI as following:
- rauth http://pypi.python.org/pypi/rauth
- oauth2client http://pypi.python.org/pypi/oauth2client
- requests-oauth2 http://pypi.python.org/pypi/requests-oauth2

I personally recommend rauth in terms of its general versatility, so I modified current link to rauth github repository, but at least please change the current link to those of some "OAuth2 supporting" client libraries.
