### PR TITLE
SoundCloud API supports OAuth2.

### DIFF
--- a/2/index.php
+++ b/2/index.php
@@ -67,7 +67,8 @@ require('../includes/_header.php');
 				<li><a href="http://developer.github.com/v3/oauth/">GitHub</a></li>
 				<li><a href="https://developers.google.com/accounts/docs/OAuth2">Google</a></li>
 				<li><a href="http://www.meetup.com/meetup_api/auth/#oauth2">Meetup</a></li>
-				<li><a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/quickstart_oauth.htm">Salesforce</a></li>
+        <li><a href="http://www.salesforce.com/us/developer/docs/api_rest/Content/quickstart_oauth.htm">Salesforce</a></li>
+				<li><a href="http://developers.soundcloud.com/docs/api/reference">SoundCloud</a></li>
 				<li><a href="https://do.com">Do.com (draft 22)</a></li>
 				<li><a href="http://msdn.microsoft.com/en-us/library/live/hh243647.aspx">Windows Live</a></li>
 			</ul>


### PR DESCRIPTION
Add a link in the services that use OAuth2 page to the SoundCloud API reference.
