### PR TITLE
adds another PHP OAuth2 server library

### DIFF
--- a/2/index.php
+++ b/2/index.php
@@ -40,6 +40,7 @@ require('../includes/_header.php');
 			    </ul>
 				</li>
 				<li><a href="https://github.com/quizlet/oauth2-php">PHP OAuth 2 Server (draft 20)</a></li>
+				<li><a href="https://github.com/bshaffer/oauth2-server-php">PHP OAuth2 Server and Demo</a></li>
 				<li><a href="https://github.com/nov/rack-oauth2">Ruby OAuth2 Server (draft 18)</a></li>
 			</ul>
 			<h4>Client Libraries</h4>


### PR DESCRIPTION
I have added another OAuth2 server library for PHP, as the only other one included in here does not seem to be supported.  It has 16 open pull requests, 27 open issues, and has only received 2 commits in 9 months. 

In addition to being currently supported and updated, the library I've submitted also has the following:
- continuous integration testing with travis-ci (260 assertions per php version for php 5.2, 5.3, and 5.4)
- PSR-compliant (namespacing and codestandards, see [PHP Fig](http://www.php-fig.org)
- support for [PHP Composer](http://getcomposer.com) package manager

It would be great to get it exposure on the oauth.net website!
