### PR TITLE
Box now supports OAuth 2

### DIFF
--- a/2/index.php
+++ b/2/index.php
@@ -81,6 +81,7 @@ require('../includes/_header.php');
 			<h4>Services that support OAuth 2</h4>
 			<ul>
 				<li><a href="http://groups.google.com/group/37signals-api/browse_thread/thread/86b0da52134c1b7e">37signals (draft 5)</a></li>
+				<li><a href="http://developers.box.com/oauth/">Box</a></li>
 				<li><a href="http://developers.facebook.com/docs/authentication/">Facebook's Graph API</a> (see <a href="http://www.sociallipstick.com/?p=239">sociallipstick.com/?p=239</a>)</li>
 				<li><a href="https://developer.foursquare.com/overview/auth">Foursquare</a></li>
 				<li><a href="https://developers.geoloqi.com">Geoloqi</a></li>


### PR DESCRIPTION
Added Box to the list of services that support the OAuth 2 spec (developers.box.com/oauth). 
