### PR TITLE
replacing python-oauth2 with rauth

### DIFF
--- a/code/index.php
+++ b/code/index.php
@@ -110,13 +110,13 @@ require('../includes/_header.php');
 			
 			<h3>Python</h3>
 			
-			<p><a href="http://stu.mp/">Joe Stump</a> (SimpleGeo) maintains the <a href="http://github.com/simplegeo/python-oauth2">python-oauth2 library</a> on GitHub, and is considered the most up-to-date and unit-tested implementation of OAuth for Python 2.4+.</p>
-			
+			<p><a href="https://github.com/maxcountryman">Max Countryman</a> maintains the <a href="https://github.com/litl/rauth">rauth></a> and it is considered the most up-to-date and unit-tested implementation of OAuth for Python.</p>			
 			<ul>
 			  <li><a href="http://leahculver.com/">Leah Culver</a> has written both a <a href="http://oauth.googlecode.com/svn/code/python/oauth/">library in Python 2.3</a> and offered an <a href="http://oauth.googlecode.com/svn/code/python/oauth/example/">example implementation</a>.</li>
 				<li>David Larlet has released an <a href="http://code.larlet.fr/django-oauth/">OAuth Provider and Consumer</a> (<a href="http://code.larlet.fr/doc/django-oauth-provider.html">documentation</a>) for Django. </li>
 				<li><a href="http://simonwillison.net">Simon Willison</a> <a href="http://simonwillison.net/2008/Mar/22/wikinear/">released</a> the <a href="http://www.djangosnippets.org/snippets/655/">snippet</a> that handles OAuth in Wikinear.</li>
 				<li>Steve Marshall wrote a <a href="http://github.com/SteveMarshall/fire-eagle-python-binding/tree/master/fireeagle_api.py">comprehensive binding for Fire Eagle</a> that implements OAuth.</li>
+				<li><a href="http://stu.mp/">Joe Stump</a> (SimpleGeo) maintains the <a href="http://github.com/simplegeo/python-oauth2">python-oauth2 library</a> on GitHub.</li>
 			</ul>
 			
 			<h3>Ruby</h3>


### PR DESCRIPTION
It would seem that rauth has become one of the most used and active
OAuth implementations for Python while python-oauth2 has not updated
in at least a year and is considered abandonware by many. Rauth is
based on simple and clean design principles and makes use of the
excellent Python Requests library. So de facto, rauth seems to be
the preferred choice. It then seems reasonable to update this list as
such.
