### PR TITLE
Update for code Python libraries

### DIFF
--- a/code/index.php
+++ b/code/index.php
@@ -114,7 +114,7 @@ require('../includes/_header.php');
 			
 			<ul>
 			  <li><a href="http://leahculver.com/">Leah Culver</a> has written both a <a href="http://oauth.googlecode.com/svn/code/python/oauth/">library in Python 2.3</a> and offered an <a href="http://oauth.googlecode.com/svn/code/python/oauth/example/">example implementation</a>.</li>
-				<li>David Larlet has released an <a href="http://code.larlet.fr/django-oauth/">OAuth Provider and Consumer</a> (<a href="http://code.larlet.fr/doc/django-oauth-provider.html">documentation</a>) for Django. </li>
+				<li>David Larlet has released an <a href="http://code.larlet.fr/django-oauth-plus/">OAuth Provider and Consumer</a> for Django. </li>
 				<li><a href="http://simonwillison.net">Simon Willison</a> <a href="http://simonwillison.net/2008/Mar/22/wikinear/">released</a> the <a href="http://www.djangosnippets.org/snippets/655/">snippet</a> that handles OAuth in Wikinear.</li>
 				<li>Steve Marshall wrote a <a href="http://github.com/SteveMarshall/fire-eagle-python-binding/tree/master/fireeagle_api.py">comprehensive binding for Fire Eagle</a> that implements OAuth.</li>
 			</ul>


### PR DESCRIPTION
The code reference for the python django library was out of date.  The django-oauth library has not been updated since 2010.  The current library is django-oauth-plus.

I updated the reference in the page.

Since the documentation now points to the same page as the "main" page I removed the extra documentation link.
