### PR TITLE
Campaign Monitor supports OAuth 2.

### DIFF
--- a/2/index.php
+++ b/2/index.php
@@ -84,6 +84,7 @@ require('../includes/_header.php');
 			<ul>
 				<li><a href="http://groups.google.com/group/37signals-api/browse_thread/thread/86b0da52134c1b7e">37signals (draft 5)</a></li>
 				<li><a href="http://developers.box.com/oauth/">Box</a></li>
+				<li><a href="http://www.campaignmonitor.com/api/getting-started/#authenticating_with_oauth">Campaign Monitor</a></li>
 				<li><a href="http://developers.facebook.com/docs/authentication/">Facebook's Graph API</a> (see <a href="http://www.sociallipstick.com/?p=239">sociallipstick.com/?p=239</a>)</li>
 				<li><a href="https://developer.foursquare.com/overview/auth">Foursquare</a></li>
 				<li><a href="https://developers.geoloqi.com">Geoloqi</a></li>


### PR DESCRIPTION
Added Campaign Monitor to the **Services that support OAuth 2** list at http://oauth.net/2/ since the [Campaign Monitor API](http://www.campaignmonitor.com/api/getting-started/#authenticating_with_oauth) now supports OAuth 2.
