### PR TITLE
Correct Apache Amber to Apache Oltu

### DIFF
--- a/2/index.php
+++ b/2/index.php
@@ -33,7 +33,7 @@ require('../includes/_header.php');
 			<ul>
 				<li>Java</a>
 				  <ul>
-				    <li><a href="http://incubator.apache.org/amber/download.html">Apache Amber (draft 22)</a>
+				    <li><a href="http://oltu.apache.org/">Apache Oltu</a>
 				    <li><a href="http://static.springsource.org/spring-security/oauth/">Spring Security for OAuth</a>
                                     <li><a href="https://github.com/OpenConextApps/apis">Apis Authorization Server (v2-31)</a>
                                     <li><a href="http://www.restlet.org/">Restlet Framework (draft 30)</a>
@@ -68,7 +68,7 @@ require('../includes/_header.php');
 				<li><a href="http://github.com/nxtbgthng/OAuth2Client">iOS and Mac OS X (draft 10)</a></li>
 				<li>Java</a>
 				  <ul>
-				    <li><a href="http://incubator.apache.org/amber/download.html">Apache Amber (draft 22)</a>
+				    <li><a href="http://oltu.apache.org/">Apache Oltu</a>
 				    <li><a href="http://www.springsource.org/spring-social">Spring Social</a>
 				    <li><a href="http://static.springsource.org/spring-security/oauth/">Spring Security for OAuth</a>
                                     <li><a href="http://www.restlet.org/">Restlet Framework (draft 30)</a>


### PR DESCRIPTION
Apache Amber was renamed to Apache Oltu in December 2012 [1](https://mail-archives.apache.org/mod_mbox/incubator-amber-dev/201212.mbox/%3CCAAqLGLPwSEmcqPMsYk_wiCUtVbD9oZeQdFoAuL2HG5uf3f=Csw@mail.gmail.com%3E). Correct
the names and links under OAuth 2.0 implementations.
