### PR TITLE
Added time cockpit to list of OAuth2-enabled services

### DIFF
--- a/2/index.php
+++ b/2/index.php
@@ -121,6 +121,7 @@ require('../includes/_header.php');
                 <li><a href="http://developers.soundcloud.com/docs/api/reference">SoundCloud</a></li>
                 <li><a href="https://do.com">Do.com (draft 22)</a></li>
                 <li><a href="http://msdn.microsoft.com/en-us/library/live/hh243647.aspx">Windows Live</a></li>
+				<li><a href="http://www.timecockpit.com/blog/2014/10/31/Welcome-OAuth2-and-OpenID-Connect">time cockpit</a></li>
             </ul>
 			
 			<h3>Legacy</h3>


### PR DESCRIPTION
Recently we added OpenID Connect/OAuth2 support to our SaaS solution time cockpit. It would be great if we could add our product to the list of OAuth2-enabled services on the website.
