### PR TITLE
Added a basic page for the http://oauth.net/grant_type/device/1.0 grant type value.

### DIFF
--- a/grant_type/1.0.html
+++ b/grant_type/1.0.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Device Flow</title>
+</head>
+<body>
+    <p>The URI <code>http://oauth.net/grant_type/device/1.0</code> is the 
+    <code>grant_type</code> value used by Google's 
+    <a href="https://developers.google.com/identity/protocols/OAuth2ForDevices">OAuth 2.0
+    for TV and Limited Input Device Applications</a> authorization flow.</p>
+</body>
+</html>
+


### PR DESCRIPTION
Describes what this URI is used for.