### PR TITLE
Update Grant info for OAuth1 and add it to the code section for OAuth2

### DIFF
--- a/1/index.php
+++ b/1/index.php
@@ -82,7 +82,7 @@ require('../includes/_header.php');
       
       <h3>Javascript</h3>
       
-      <p><a href="https://github.com/simov">Simeon Velichkov</a> has written a <a href="https://github.com/simov/grant">OAuth middleware for Koa and Express</a>. 80+ supported providers for both OAuth and OAuth2 <a href="https://www.npmjs.com/package/grant">npm package</a>.</p>
+      <p><a href="https://github.com/simov">Simeon Velichkov</a> has written a <a href="https://github.com/simov/grant">OAuth middleware for Express, Koa and Hapi</a>. 150+ supported providers for both OAuth and OAuth2 <a href="https://www.npmjs.com/package/grant">npm package</a>.</p>
 
       <p><a href="http://www.ddo.me">Ddo</a> has contributed a <a href="https://github.com/joeddo/oauth-1.0a">OAuth 1.0a Request Authorizer (Send OAuth request with your favorite HTTP client as request, jQuery.ajax...)</a></p>
       

--- a/code/index.php
+++ b/code/index.php
@@ -147,6 +147,7 @@ require('../includes/_header.php');
       </li>
       <li>Node.js
         <ul>
+          <li><a href="https://github.com/simov/grant">Grant</a></li>
           <li><a href="http://passportjs.org/">PassportJS</a></li>
           <li><a href="https://github.com/zalando/oauth2-client-js">OAuth2-client-js</a></li>
         </ul>


### PR DESCRIPTION
Hi,

I noticed that the site structure has changed a bit since I submitted my first PR https://github.com/aaronpk/oauth.net/pull/90/files about Grant.

Grant is OAuth1 client and OAuth2 authorization_code client middleware for NodeJS, supporting Express, Koa and Hapi.

I updated the existing information for OAuth1, and added the library to the code section for OAuth2.

The showcase application can be found here: https://grant.outofindex.com