### PR TITLE
Added gin-oauth2 to the "Server Libraries"/Golang

### DIFF
--- a/code/index.php
+++ b/code/index.php
@@ -83,6 +83,7 @@ require('../includes/_header.php');
       <li>Golang
         <ul>
           <li><a href="https://github.com/go-oauth2/oauth2">Golang OAuth 2 Server framework</a></li>
+          <li><a href="https://github.com/zalando/gin-oauth2">gin-oauth2</a>: middleware for Gin Framework users who also want to use OAuth2</li>
         </ul>
       </li>
     </ul>


### PR DESCRIPTION
gin-oauth2 (https://github.com/zalando/gin-oauth2) is open-source Golang middleware for Gin Framework users who also want to use OAuth2.