### PR TITLE
removed malformed link and replaced reference to expired CC license with reference to its replacement.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,14 +7,14 @@ The license that the oauth.net site uses places all content added on or after 20
 
 ## Contributors Rights and Obligations
 
-Similar to [Wikipedia's contributors' rights and obligations](http://en.wikipedia.org/wiki/Wikipedia:Copyrights#Contributors.27_rights_and_obligations), by submitting content to the oauth.net repository, you release your work to the public domain, and thus grant oauth.net viewers permission to use, copy, distribute and/or modify your work under the terms of the [Creative Commons Public Domain License](http://creativecommons.org/licenses/publicdomain/), the original at [http://creativecommons.org/licenses/publicdomain/](creativecommons.org/licenses/publicdomain/) or any later version published by Creative Commons; with either a waiver of rights, or an assertion that no rights attach to a particular work.
+Similar to [Wikipedia's contributors' rights and obligations](http://en.wikipedia.org/wiki/Wikipedia:Copyrights#Contributors.27_rights_and_obligations), by submitting content to the oauth.net repository, you release your work to the public domain, and thus grant oauth.net viewers permission to use, copy, distribute and/or modify your work under the terms of the [Creative Commons Public Domain](https://creativecommons.org/share-your-work/public-domain/cc0/) or any later version published by Creative Commons; with either a waiver of rights, or an assertion that no rights attach to a particular work.
 
 Note that this applies only to the content submitted to the oauth.net site, not to the code to which you may be adding a link.
 
 In order to contribute, you must be in a position to agree to the terms of this license, which means that either:
 
-* you hold the copyright to the material, for instance because you produced it yourself, or
-* because the material is in the public domain
+* you hold the copyright to the material, for instance because you produced it yourself and are therefore entitled to waive those interests, or
+* because the material is in the public domain.
 
 In the first case, you release copyright to your materials. You can later republish them in any way you like. However, you can never retract the public domain license for the copies of materials that you place here; these copies will remain under public domain license.
 


### PR DESCRIPTION
removed malformed link and replaced reference to expired CC license with reference to its replacement.