### PR TITLE
Update article title.

### DIFF
--- a/articles/authentication/index.php
+++ b/articles/authentication/index.php
@@ -1,6 +1,6 @@
 <?php
 
-$page_title = "End User Authentication with OAuth 2.0 &mdash; OAuth";
+$page_title = "User Authentication based on OAuth 2.0 &mdash; OAuth";
 $page_section = "articles";
 $page_secondary = "authentication";
 $page_meta_description = "Performing end user authentication using the OAuth 2.0 protocol.";
@@ -18,7 +18,7 @@ require('../../includes/_header.php');
     </div>
 
     <div id="main" class="column first last span-18 prepend-1 append-1">
-      <h2 id="oauth-2.0-authentication">User Authentication with OAuth 2.0</h2>
+      <h2 id="oauth-2.0-authentication">User Authentication based on OAuth 2.0</h2>
   
       <!-- Article compiled and edited by Justin Richer -->
 

--- a/articles/index.php
+++ b/articles/index.php
@@ -26,7 +26,7 @@ require('../includes/_header.php');
 
       <h3>End User Authentication with OAuth 2.0</h3>
 
-  	  <p>While OAuth is not an authentication protocol on its own, there are a number of high-profile authentication protocols built with OAuth 2.0. This article seeks to expose common pitfalls and demonstrate <a href="/articles/authentication">how to do end user authentication using OAuth 2.0</a> in a secure and reliable manner.</p>
+  	  <p>While OAuth is not an authentication protocol on its own, there are a number of high-profile authentication protocols built with OAuth 2.0. This article seeks to expose common pitfalls and demonstrate <a href="/articles/authentication">how to do end user authentication based on OAuth 2.0</a> in a secure and reliable manner.</p>
 	  
       <h3>OAuth 2 Simplified</h3>
 


### PR DESCRIPTION
When I read this article([https://oauth.net/articles/authentication/](https://oauth.net/articles/authentication/)),  the title of the article makes me feel OAuth 2.0 is an authentication protocol, but in fact is not, there is some ambiguity exists.So I think we can change the title of the article.