### PR TITLE
Create short URL for the OAuth Security Workshop

### DIFF
--- a/workshop/next/index.php
+++ b/workshop/next/index.php
@@ -1,0 +1,3 @@
+<?php
+// Send a redirect to the next issue of the OAuth Security Workshop
+header('Location: https://sec.uni-stuttgart.de/events/osw2019');


### PR DESCRIPTION
At https://sec.uni-stuttgart.de/events/osw2019, we will soon publish more information and the registration for the next OAuth Security Workshop, which in 2019 will be held at the University of Stuttgart, Germany. It would be great to create a short URL to the conference page, and update it for the workshops in the next years.