### PR TITLE
Add FastAPI to OAuth2 servers

### DIFF
--- a/code/data.php
+++ b/code/data.php
@@ -53,6 +53,7 @@ $languages['python'] = [
     '<a href="https://github.com/lepture/flask-oauthlib">Flask-OAuthlib</a> is an OAuth2 Client/Provider for Flask built upon <a href="https://github.com/oauthlib/oauthlib">oauthlib</a>',
     '<a href="https://github.com/lepture/authlib">Authlib</a> has an OAuth2 and OpenID Connect Provider, generic and Flask.</a>',
     '<a href="https://github.com/thomsonreuters/bottle-oauthlib">Bottle-OAuthlib</a> is the simplest library to build OAuth2/OIDC Provider on top of Bottle and <a href="https://github.com/oauthlib/oauthlib">oauthlib</a>',
+    '<a href="https://github.com/tiangolo/fastapi">FastAPI</a> is a modern, fast (high-performance), web framework for building APIs with Python 3.6+ based on standard Python type hints. It includes support for OAuth2, integrated with OpenAPI',
   ],
   'client_libraries' => [
     '<a href="http://github.com/demianbrecht/sanction">sanction</a>',


### PR DESCRIPTION
Add FastAPI to OAuth2 servers :smile: 

FastAPI has utilities to handle all the OAuth2 flows in the server side, integrated with OpenAPI. Including the definition of scopes per route.