### PR TITLE
Use PHPUnit Data Providers to run the test once for every data file

### DIFF
--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -4,27 +4,35 @@ use Symfony\Component\HttpFoundation\Response;
 
 class EventTest extends PHPUnit\Framework\TestCase {
 
-  public function testJSONFileSyntax() {
+  /**
+   * @dataProvider eventJSON
+   */
+  public function testJSONFileSyntax($event, $f) {
+
+    if($event == null) {
+      $this->fail('JSON syntax error in file: '.$f);
+    }
+
+    // Check for required fields
+    $this->assertArrayHasKey('name', $event, 'Filename: '.$f);
+    $this->assertArrayHasKey('start_date', $event, 'Filename: '.$f);
+    $this->assertArrayHasKey('location', $event, 'Filename: '.$f);
+    $this->assertArrayHasKey('url', $event, 'Filename: '.$f);
+
+    // Check that start date looks like a date
+    $this->assertRegexp('/\d{4}-\d{2}-\d{2}/', $event['start_date'], 'Filename: '.$f);
+
+    // Check that the URL is a URL
+    $this->assertRegexp('/https?:\/\/.+/', $event['url'], 'Filename: '.$f);
+
+  }
+
+  public function eventJSON()
+  {
 
     $files = glob(__DIR__.'/../events/data/*.json');
     foreach($files as $f) {
-      $event = json_decode(file_get_contents($f), true);
-
-      if($event == null) {
-        $this->fail('JSON syntax error in file: '.$f);
-      }
-
-      // Check for required fields
-      $this->assertArrayHasKey('name', $event, 'Filename: '.$f);
-      $this->assertArrayHasKey('start_date', $event, 'Filename: '.$f);
-      $this->assertArrayHasKey('location', $event, 'Filename: '.$f);
-      $this->assertArrayHasKey('url', $event, 'Filename: '.$f);
-
-      // Check that start date looks like a date
-      $this->assertRegexp('/\d{4}-\d{2}-\d{2}/', $event['start_date'], 'Filename: '.$f);
-
-      // Check that the URL is a URL
-      $this->assertRegexp('/https?:\/\/.+/', $event['url'], 'Filename: '.$f);
+      yield basename($f) => [json_decode(file_get_contents($f), true), $f];
     }
 
   }


### PR DESCRIPTION
The test now uses a data provider that will feed it the JSON object as well as the file path. The latter is not strictly necessary but is used for the error messages.

This means all JSON files will be checked when the test runs so all errors can be fixed in one go, rather than the test stopping at the first failure.

Example run where a letter slipped into the date:

```
PHPUnit 8.0.4 by Sebastian Bergmann and contributors.

.........F.......                                                 17 / 17 (100%)

Time: 52 ms, Memory: 4.00 MB

There was 1 failure:

1) EventTest::testJSONFileSyntax with data set "internet-identity-workshop-xxvii.json" (array('Internet Identity Workshop XXVII', '2018-10-a23', '2018-10-25', 'Computer History Museum, Moun...fornia', 'http://www.internetidentitywo...p.com/'), '/private/tmp/oauth.net/tests/...i.json')
Filename: /private/tmp/oauth.net/tests/../events/data/internet-identity-workshop-xxvii.json
Failed asserting that '2018-10-a23' matches PCRE pattern "/\d{4}-\d{2}-\d{2}/".

/private/tmp/oauth.net/tests/EventTest.php:23

FAILURES!
Tests: 17, Assertions: 101, Failures: 1.
```