### PR TITLE
Updated ORY Hydra URL

### DIFF
--- a/code/index.php
+++ b/code/index.php
@@ -67,7 +67,7 @@ require('./data.php');
       <li><a href="https://auth0.com">Auth0</a></li>
       <li><a href="https://curity.io">Curity Identity Server</a></li>
       <li><a href="https://fusionauth.io/">FusionAuth</a></li>
-      <li><a href="https://github.com/ory/hydra">ORY Hydra</a></li>
+      <li><a href="https://ory.sh/hydra">ORY Hydra</a></li>
       <li><a href="https://github.com/oauth-io">OAuth.io</a></li>
       <li><a href="https://developer.okta.com">Okta</a></li>
       <li><a href="https://github.com/ssqsignon">SSQ signon</a></li>


### PR DESCRIPTION
I updated the ORY Hydra URL from GitHub to ory.sh/hydra which is more representative than the GitHub page (has docs, github, forum, chat, ...).