### PR TITLE
Distinguish between commercial and open source

### DIFF
--- a/code/index.php
+++ b/code/index.php
@@ -63,18 +63,26 @@ require('./data.php');
 
     <h3 id="services">OAuth Services</h3>
     <span id="proxy-services"></span>
+    
+    <h4 id="services">Open Source</h4>
+    <span id="proxy-services-open-source"></span>
+    <ul>
+      <li><a href="https://github.com/ory/hydra">ORY Hydra</a></li>
+      <li><a href="https://github.com/oauth-io">OAuth.io</a></li>
+      <li><a href="https://github.com/ssqsignon">SSQ signon</a></li>
+      <li><a href="https://github.com/babelouest/glewlwyd">Glewlwyd</a></li>
+    </ul>
+    
+    <h4 id="services">Commercial</h4>
+    <span id="proxy-services-commercial"></span>
     <ul>
       <li><a href="https://auth0.com">Auth0</a></li>
       <li><a href="https://curity.io">Curity Identity Server</a></li>
       <li><a href="https://fusionauth.io/">FusionAuth</a></li>
-      <li><a href="https://github.com/ory/hydra">ORY Hydra</a></li>
-      <li><a href="https://github.com/oauth-io">OAuth.io</a></li>
       <li><a href="https://developer.okta.com">Okta</a></li>
-      <li><a href="https://github.com/ssqsignon">SSQ signon</a></li>
-      <li><a href="https://github.com/babelouest/glewlwyd">Glewlwyd</a></li>
       <li><a href="https://simplelogin.io">SimpleLogin</a></li>
     </ul>
-
+    
     <?php /*
     <h3 id="services-that-support-oauth-2">Services that Support OAuth 2</h3>
     <ul>

--- a/code/index.php
+++ b/code/index.php
@@ -68,7 +68,7 @@ require('./data.php');
     <span id="proxy-services-open-source"></span>
     <ul>
       <li><a href="https://github.com/oauth-io">OAuth.io</a></li>
-      <li><a href="https://github.com/ory/hydra">ORY Hydra</a></li>
+      <li><a href="https://www.ory.sh/hydra">ORY Hydra</a></li>
       <li><a href="https://github.com/ssqsignon">SSQ signon</a></li>
       <li><a href="https://github.com/babelouest/glewlwyd">Glewlwyd</a></li>
     </ul>


### PR DESCRIPTION
This patch closes #203 by distinguishing between commercial and open source OAuth 2.0 offerings. This hopefully clarifies developers researching the topic on what's what and helps them quickly choose a category that works for them and research the software or commercial offering behind it.