### PR TITLE
Add OAuth courses from multiple popular providers via Classpert

### DIFF
--- a/videos/index.php
+++ b/videos/index.php
@@ -28,6 +28,7 @@ require('../includes/_header.php');
         <li><a href="https://www.youtube.com/watch?v=996OiexHze0">OAuth 2.0 and OpenID Connect (in plain English)</a> by Nate Barbettini</li>
         <li><a href="https://www.youtube.com/watch?v=rZRwE3d-gm0">Using OAuth and OpenID Connect in Your Applications - Oktane 18</a> by Aaron Parecki and Padma Govindarajalu</li>
         <li><a href="https://www.youtube.com/watch?v=vjCF_O6aZIg">Vulnerabilities of mobile OAuth 2.0</a> by Nikita Stupin</li>
+        <li><a href="https://classpert.com/oauth">Free and paid OAuth courses from popular e-learning providers (Classpert)</a></li>
       </ul>
 
       <div style="clear:both;"></div>


### PR DESCRIPTION
This commit will add a link to a collection of OAuth courses (free and paid) from popular providers like Udemy, Skillshare, Pluralsight and Udacity (and many others to come). Classpert is a search and comparison site for online courses that aims to organize the chaotic online course landscape on the internet. Classpert is 100% free from a user standpoint

_disclaimer: If you believe this isn't the appropriate space for adding this type of link feel free to refuse my PR and suggesting other directions and alternatives_