### PR TITLE
Fix the URL for the GO OAuth1 package

### DIFF
--- a/1/index.php
+++ b/1/index.php
@@ -58,7 +58,7 @@ require('../includes/_header.php');
 
       <p><a href="https://godoc.org/github.com/gomodule/oauth1/oauth">Go-Oauth</a> is an OAuth 1 client package.</p>
       
-      <p><a href="https://godoc.org/github.com/gomodule/oauth1/oauth">OAuth1</a> is an OAuth 1 client takes design cues from <a href="https://godoc.org/golang.org/x/oauth2">golang.org/x/oauth2</a>.</p>
+      <p><a href="https://godoc.org/github.com/dghubble/oauth1">OAuth1</a> is an OAuth 1 client takes design cues from <a href="https://godoc.org/golang.org/x/oauth2">golang.org/x/oauth2</a>.</p>
 
       <h3>Java</h3>
 


### PR DESCRIPTION
Both GO packages by mistake link to the same URL. 