### PR TITLE
Add link to oauth.com documentation for Password Grant

### DIFF
--- a/2/grant-types/password/index.php
+++ b/2/grant-types/password/index.php
@@ -26,6 +26,7 @@ require('../../../includes/_header.php');
 
     <p>More resources
       <ul>
+        <li><a href="https://www.oauth.com/oauth2-servers/access-tokens/password-grant/">Password Grant</a> (oauth.com)</li>
         <li><a href="https://developer.okta.com/blog/2018/06/29/what-is-the-oauth2-password-grant">What is the OAuth 2.0 Password Grant Type?</a> (developer.okta.com)</li>
         <li><a href="https://tools.ietf.org/html/draft-ietf-oauth-security-topics-13#section-3.4">Section 3.4 of OAuth 2.0 Security Best Current Practice</a></li>
         <li><a href="https://aaronparecki.com/oauth-2-simplified/#password">Password</a> (aaronparecki.com)</li>


### PR DESCRIPTION
This adds a link to the oauth.com documentation for the Password Grant flow, like there is for https://oauth.net/2/grant-types/authorization-code/ and https://oauth.net/2/grant-types/client-credentials/.