### PR TITLE
Add Osso to open source

### DIFF
--- a/code/index.php
+++ b/code/index.php
@@ -71,6 +71,7 @@ require('./data.php');
       <li><a href="https://www.keycloak.org">Keycloak</a></li>      
       <li><a href="https://github.com/oauth-io">OAuth.io</a></li>
       <li><a href="https://www.ory.sh/hydra">ORY Hydra</a></li>
+      <li><a href="https://github.com/enterprise-oss/osso">Osso</a></li>
       <li><a href="https://simplelogin.io/developer">SimpleLogin</a></li>
       <li><a href="https://github.com/ssqsignon">SSQ signon</a></li>
     </ul>


### PR DESCRIPTION
I'm the maintainer of Osso, an open source service that handles SAML SSO against enterprise Identity Providers and makes those users available to a developer via an OAuth 2.0 authorization flow. We sorta wrap SAML (which requires a per-instance configuration) in OAuth 2.0, which makes adding SSO a lot easier for an engineering team.

I hope this is a welcome addition, but admittedly perhaps not 🤞 

You can learn more at https://ossoapp.com or https://github.com/enterprise-oss/osso 