### PR TITLE
Add oauth1-hmac as an OAuth1.0 Java Library

### DIFF
--- a/1/index.php
+++ b/1/index.php
@@ -72,6 +72,8 @@ require('../includes/_header.php');
 
       <p><a href="https://github.com/kovacshuni/koauth">KOAauth</a> is a great library for both providers and consumers written by <a href="http://www.hunorkovacs.com">Hunor Kovács</a>. Originally it was intended for Scala but could be fully used in Java as well.</p>
 
+      <p><a href="https://github.com/omarathon/oauth1-hmac">oauth1-hmac</a> is a lightweight OAuth1.0 consumer library, using the HMAC signing strategy. It wraps <a href="https://developers.google.com/api-client-library/java/google-oauth-java-client">Google's OAuth Client Library for Java</a>, providing a simple API for a generic OAuth1.0 consumer. Written by <a href="https://www.linkedin.com/in/omartanner">Omar Tanner</a>.</p>
+      
       <h3>Javascript</h3>
 
       <p><a href="https://github.com/simov">Simeon Velichkov</a> has written a <a href="https://github.com/simov/grant">OAuth Proxy</a>. 200+ OAuth providers for Express, Koa, Hapi, Fastify, AWS Lambda, Azure, Google Cloud, Vercel <a href="https://www.npmjs.com/package/grant">npm package</a>.</p>


### PR DESCRIPTION
Recently, as a result of open-sourcing some of my code in an academic project, I made an OAuth1.0 consumer library for Java, named oauth1-hmac (https://github.com/omarathon/oauth1-hmac). It's a very lightweight library wrapping Google's OAuth Client Library for Java (https://developers.google.com/api-client-library/java/google-oauth-java-client), piecing together the APIs in Google's library to provide a simple API for a generic OAuth1.0 consumer. Note: it only works with the HMAC signing strategy.

I figured it may be handy for someone if they're having to interface with a legacy OAuth1.0 provider, and are wanting to get going quickly. Personally I struggled implementing the consumer for my application, so I'm sharing the work in a generic form to hopefully prevent another person's struggle.

The library has been tested, and is being used in production on ModulePal (https://modulepal.com). I also made an example Spring application using it to implement a consumer for Warwick University's OAuth1.0 provider, which is available at https://github.com/omarathon/java-spring-warwick-sso-oauth-example. Such application is being listed as an official example on Warwick University's list of example applications for their OAuth1.0 provider: https://warwick.ac.uk/services/its/servicessupport/web/sign-on/help/oauth/apis.