### PR TITLE
Mention problems with Qt when doing Google SSO

### DIFF
--- a/code/data.php
+++ b/code/data.php
@@ -230,7 +230,7 @@ $languages['qt'] = [
   'name' => 'QT / C++',
   'client_libraries' => [
     '<a href="https://github.com/pipacs/o2">O2 (supports OAuth 1.0a and 2.0)</a>',
-    '<a href="https://wiki.qt.io/New_Features_in_Qt_5.8">Qt Network Authentication (since 5.8, supports OAuth 1 and 2)</a>',
+    '<a href="https://wiki.qt.io/New_Features_in_Qt_5.8">Qt Network Authentication (since 5.8, supports OAuth 1 and 2)</a>; Has format problems with <a href="https://appfluence.com/productivity/how-to-authenticate-qt-google-sso/">codes by Google SSO</a>.',
   ],
 ];
 


### PR DESCRIPTION
There are lots of folks confused with the Qt-provided examples for doing Google SSO authentication with their native desktop apps using Qt. This PR adds a link to a discussion of the issue, and a workaround until Qt fixes the problem.