### PR TITLE
Add PKCE link to the Grant Types index

### DIFF
--- a/public/2/grant-types/index.php
+++ b/public/2/grant-types/index.php
@@ -23,6 +23,7 @@ require('../../../includes/_header.php');
 
     <ul>
       <li><a href="/2/grant-types/authorization-code/">Authorization Code</a></li>
+      <li><a href="/2/pkce/">PKCE</a></li>
       <li><a href="/2/grant-types/client-credentials/">Client Credentials</a></li>
       <li><a href="/2/grant-types/device-code/">Device Code</a></li>
       <li><a href="/2/grant-types/refresh-token/">Refresh Token</a></li>


### PR DESCRIPTION
This aligns the Grant Types index page with the top-level index page.