### PR TITLE
Remove insecure statement for public clients

### DIFF
--- a/public/2/pkce/index.php
+++ b/public/2/pkce/index.php
@@ -18,7 +18,7 @@ require('../../../includes/_header.php');
 
     <p><a href="http://tools.ietf.org/html/rfc7636" class="rfc">tools.ietf.org/html/rfc7636</a></p>
 
-    <p>PKCE (<a href="http://tools.ietf.org/html/rfc7636">RFC 7636</a>) is an extension to the <a href="/2/grant-types/authorization-code/">Authorization Code flow</a> to prevent several attacks and to be able to securely perform the OAuth exchange from public clients.</p>
+    <p>PKCE (<a href="http://tools.ietf.org/html/rfc7636">RFC 7636</a>) is an extension to the <a href="/2/grant-types/authorization-code/">Authorization Code flow</a> to prevent several attacks and to be able to exchange an `authorization_code` for an `access_token` in a more secure way from public clients.</p>
     <p>It was originally designed to protect mobile apps, but its ability to prevent authorization code injection makes it useful for every OAuth client, even web apps that use a client secret.</p>
 
     <p>Videos

--- a/public/2/pkce/index.php
+++ b/public/2/pkce/index.php
@@ -20,6 +20,7 @@ require('../../../includes/_header.php');
 
     <p>PKCE (<a href="http://tools.ietf.org/html/rfc7636">RFC 7636</a>) is an extension to the <a href="/2/grant-types/authorization-code/">Authorization Code flow</a> to prevent several attacks and to be able to exchange an `authorization_code` for an `access_token` in a more secure way from public clients.</p>
     <p>It was originally designed to protect mobile apps, but its ability to prevent authorization code injection makes it useful for every OAuth client, even web apps that use a client secret.</p>
+    <p>Note: PKCE is <em>not</em> a replacement for client authentication and therefore does <em>not</em> allow a public client to replace a confidential client (nor treat it as such)</p>
 
     <p>Videos
       <ul>


### PR DESCRIPTION
Although PKCE makes it *more* secure, it does not enable secure OAuth exchange from public clients.

This misinformation leads to misunderstandings like 
> ["TLDR: The PKCE flow is a secure way to authenticate public clients."](https://kevcodez.de/posts/2020-06-07-pkce-oauth2-auth-flow-cli-desktop-app/)

And other examples described in https://www.scottbrady91.com/oauth/client-authentication-vs-pkce