### PR TITLE
Fix URL for oauth2 gem

### DIFF
--- a/data/code/ruby.yml
+++ b/data/code/ruby.yml
@@ -1,8 +1,7 @@
 ---
 name: Ruby
 client_libraries:
-- <a href="http://github.com/intridea/oauth2">Ruby Gem</a>
-- <a href="http://github.com/aflatter/oauth2-ruby">Ruby</a>
+- <a href="http://github.com/oauth-xx/oauth2">Oauth2 Ruby Gem - Wrapper for the OAuth 2.0 spec</a>
 - <a href="https://github.com/nov/rack-oauth2">Rack::OAuth2 - OAuth 2.0 Server & Client
   Library in Ruby.</a>
 server_libraries:


### PR DESCRIPTION
- remove reference to archived-for-12-years-now `oauth2-server` gem