### PR TITLE
Adding rodauth-oauth to the list

### DIFF
--- a/data/code/ruby.yml
+++ b/data/code/ruby.yml
@@ -9,4 +9,5 @@ server_libraries:
   for Ruby on Rails / Grape.</a>
 - <a href="https://github.com/nov/rack-oauth2">Rack::OAuth2 - OAuth 2.0 Server & Client
   Library in Ruby.</a>
+- <a href="https://gitlab.com/honeyryderchuck/rodauth-oauth">Rodauth OAuth - OAuth and OpenID provider toolkit.</a>
 ...


### PR DESCRIPTION
[rodauth-oauth](https://gitlab.com/honeyryderchuck/rodauth-oauth) builds on top of the rodauth authentication framework to provide an easy extensible way to build OAuth an OIDC authorization servers.