### PR TITLE
Add Omejdn to Open Source Authorization Servers

### DIFF
--- a/public/code/index.php
+++ b/public/code/index.php
@@ -71,6 +71,7 @@ $languages = json_decode(file_get_contents(__DIR__.'/../../data/code/languages.j
       <li><a href="https://github.com/curveball/a12n-server">a12n-server</a></li>
       <li><a href="https://github.com/casbin/casdoor">Casdoor</a></li>
       <li><a href="https://github.com/babelouest/glewlwyd">Glewlwyd</a></li>
+      <li><a href="https://github.com/Fraunhofer-AISEC/omejdn-server">Omejdn</a></li>
       <li><a href="https://www.keycloak.org">Keycloak</a></li>
       <li><a href="https://github.com/oauth-io">OAuth.io</a></li>
       <li><a href="https://www.ory.sh/hydra">ORY Hydra</a></li>


### PR DESCRIPTION
About Omejdn:
"Omejdn" is bavarian for "Log In". The Server written in Ruby tries to support both OAuth 2.0/2.1 and OpenID Connect while following the Security BCP, along with many current features such as Server Metadata, JWT Access Tokens, Pushed Authorization Requests, ...
It currently does not support Dynamic Client Registration and Management.

It tries to maintain a minimal code base and to be easily extensible, making it suitable as a base for research projects.