### PR TITLE
Improve python libraries page

### DIFF
--- a/data/code/python.yml
+++ b/data/code/python.yml
@@ -1,10 +1,6 @@
 ---
 name: Python
 server_libraries:
-- <a href="https://github.com/TransparentHealth/hhs_oauth_server">HHS OAuth2 Server
-  (Healthcare Focused)</a>
-- <a href="https://github.com/NateFerrero/oauth2lib"> Python OAuth 2.0 Client + Server
-  Library</a>
 - <a href="https://github.com/evonove/django-oauth-toolkit">Django OAuth Toolkit (DOT)</a>
   is an OAuth2 Provider for Django built upon <a href="https://github.com/oauthlib/oauthlib">oauthlib</a>
 - <a href="https://github.com/lepture/authlib">Authlib</a> has an OAuth2 and OpenID
@@ -12,17 +8,13 @@ server_libraries:
 - <a href="https://github.com/thomsonreuters/bottle-oauthlib">Bottle-OAuthlib</a>
   is the simplest library to build OAuth2/OIDC Provider on top of Bottle and <a href="https://github.com/oauthlib/oauthlib">oauthlib</a>
 - <a href="https://github.com/tiangolo/fastapi">FastAPI</a> is a modern, fast (high-performance),
-  web framework for building APIs with Python 3.6+ based on standard Python type hints.
+  web framework for building APIs based on standard Python type hints.
   It includes support for OAuth2, integrated with OpenAPI
-- <a href="https://github.com/aliev/aioauth">aioauth</a> Asynchronous OAuth 2.0 library for Python 3
+- <a href="https://github.com/aliev/aioauth">aioauth</a> Asynchronous OAuth 2.0 library
 client_libraries:
-- <a href="http://github.com/demianbrecht/sanction">sanction</a>
-- <a href="http://github.com/litl/rauth">rauth</a>
 - <a href="http://authomatic.github.io/authomatic/">Authomatic</a>
 - <a href="https://python-social-auth.readthedocs.io/en/latest/"> Python Social Auth</a>
   is an OAuth and OAuth2 client for a multitude of services.
-- <a href="https://github.com/lepture/flask-oauthlib">Flask-OAuthlib</a> is an OAuth2
-  Client/Provider for Flask built upon <a href="https://github.com/oauthlib/oauthlib">oauthlib</a>
 - <a href="https://github.com/lepture/authlib">Authlib</a> has built-in OAuth 2 client
   for Flask and Django.</a>
 - <a href="https://github.com/requests/requests-oauthlib">Requests-OAuthlib</a> has


### PR DESCRIPTION
- Removed the following references to unmaintained projects
  - https://github.com/TransparentHealth/hhs_oauth_server
  - https://github.com/NateFerrero/oauth2lib 
  - https://github.com/demianbrecht/sanction
  - http://github.com/litl/rauth
  - https://github.com/lepture/flask-oauthlib
- Removed references to Python 3