### PR TITLE
Add Spring Authorization Server to index.php

### DIFF
--- a/public/code/index.php
+++ b/public/code/index.php
@@ -77,6 +77,7 @@ $languages = json_decode(file_get_contents(__DIR__.'/../../data/code/languages.j
       <li><a href="https://github.com/oauth-io">OAuth.io</a></li>
       <li><a href="https://www.ory.sh/hydra">ORY Hydra</a></li>
       <li><a href="https://simplelogin.io/developer">SimpleLogin</a></li>
+      <li><a href="https://github.com/spring-projects/spring-authorization-server">Spring Authorization Server</a></li>
       <li><a href="https://github.com/ssqsignon">SSQ signon</a></li>
       <li><a href="https://wso2.com/identity-server/">WSO2 Identity Server</a></li>
       <li><a href="https://github.com/zitadel/zitadel">ZITADEL</a></li>   


### PR DESCRIPTION
The Spring Authorization Server project, led by the [Spring Security](https://spring.io/projects/spring-security/) team, is focused on delivering [OAuth 2.1 Authorization Server](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-07#section-1.1) support to the Spring community.