### PR TITLE
docs: add go-dpop library

### DIFF
--- a/data/code/go.yml
+++ b/data/code/go.yml
@@ -2,10 +2,12 @@
 name: Go
 client_libraries:
 - <a href="http://godoc.org/golang.org/x/oauth2">Go OAuth 2.0 Client</a>
+- '<a href="https://pkg.go.dev/github.com/AxisCommunications/go-dpop">go-dpop</a>: Golang DPoP client and server library'
 server_libraries:
 - '<a href="https://github.com/ory/fosite">Fosite</a>: Extensible security first OAuth
   2.0 and OpenID Connect SDK for Go.'
 - <a href="https://github.com/go-oauth2/oauth2">Golang OAuth 2 Server framework</a>
 - '<a href="https://github.com/zalando/gin-oauth2">gin-oauth2</a>: middleware for
   Gin Framework users who also want to use OAuth2'
+- '<a href="https://pkg.go.dev/github.com/AxisCommunications/go-dpop">go-dpop</a>: Golang DPoP client and server library'
 ...


### PR DESCRIPTION
Add link to new go library implementing DPoP.

Feedback on if (not) this belongs here is appreciated.