### PR TITLE
Link to library instead of standalone version

### DIFF
--- a/data/code/elixir.yml
+++ b/data/code/elixir.yml
@@ -6,6 +6,6 @@ server_libraries:
 - '<a href="https://github.com/danschultzer/ex_oauth2_provider">Elixir OAuth2 Server</a>:
   The no-brainer library to use for adding OAuth 2.0 provider capabilities to your
   Elixir app.'
-- '<a href="https://github.com/malach-it/boruta-server">Boruta</a>:
+- '<a href="https://github.com/malach-it/boruta_auth">Boruta</a>:
   OAuth / OpenID Connect provider core for Elixir.'
 ...


### PR DESCRIPTION
It would be great to have the library version linked in that page.

Thank you.