### PR TITLE
Update index.php

### DIFF
--- a/public/code/index.php
+++ b/public/code/index.php
@@ -83,6 +83,7 @@ $languages = json_decode(file_get_contents(__DIR__.'/../../data/code/languages.j
       <li><a href="https://wso2.com/identity-server/">WSO2 Identity Server</a></li>
       <li><a href="https://github.com/zitadel/zitadel">ZITADEL</a></li>   
       <li><a href="https://github.com/malach-it/boruta-server">boruta</a></li>
+      <li><a href="https://github.com/logto-io/logto">Logto</a></li>
     </ul>
 
     <h4 id="commercial">Commercial</h4>
@@ -105,6 +106,7 @@ $languages = json_decode(file_get_contents(__DIR__.'/../../data/code/languages.j
       <li><a href="https://stytch.com/?utm_source=oauth.net">Stytch</a></li>
       <li><a href="https://zitadel.com">ZITADEL Cloud</a></li>
       <li><a href="https://www.ibm.com/cloud/app-id">IBM Cloud App ID</a></li>
+      <li><a href="https://logto.io">Logto</a></li>
     </ul>
 
     <h3 id="related">Related Projects and Services</h3>


### PR DESCRIPTION
Add Logto to OAuth Providers list

- [Logto Opensource](https://github.com/logto-io/logto)
- [Logto Cloud](https://logto.io/)

Logto is a modern Auth0 alternative that provides a comprehensive customer identity solution, available in both open-source and cloud versions:

- Open Source Edition:
  - 456,000+ Docker pulls
  - 9,100+ GitHub stars
  - Self-hostable identity solution

- Cloud Edition (Commercial):
  - Trusted by 10,000+ users
  - Enterprise-grade features and support

Key highlights:
- Complete auth solution for web, mobile, and native apps with 20+ modern frameworks
- Replacement for Auth0
- Full-featured identity platform with multi-protocol support (OAuth 2.0, OIDC, SAML)

Adding Logto to both open-source and commercial sections as it offers both deployment options.