### PR TITLE
Fix loginradius.com link in PKCE docs

### DIFF
--- a/public/2/pkce/index.php
+++ b/public/2/pkce/index.php
@@ -44,7 +44,7 @@ require('../../../includes/_header.php');
       <li><a href="https://aaronparecki.com/oauth-2-simplified/#mobile-apps">Mobile Apps</a> (aaronparecki.com)</li>
       <li><a href="https://developers.google.com/identity/protocols/OAuth2InstalledApp">OAuth 2.0 for Mobile &amp; Desktop Apps</a> (developers.google.com)</li>
       <li><a href="https://developer.okta.com/blog/2018/12/13/oauth-2-for-native-and-mobile-apps">OAuth 2.0 for Native and Mobile Apps</a> (developer.okta.com by Micah Silverman)</li>
-       <li><a href="https://www.loginradius.com/engineering/blog/pkce/">All about PKCE in OAuth 2.0</a> (loginradius.com by Narendra Pareek)</li>
+       <li><a href="https://www.loginradius.com/blog/engineering/pkce/">All about PKCE in OAuth 2.0</a> (loginradius.com by Narendra Pareek)</li>
     </ul>
 
   </div>


### PR DESCRIPTION
Current docs links to a dead link which redirects to `https://www.loginradius.com/blog/pkce/` which returns with the contents of `You just hit a route that doesn't exist... the sadness.`

Changed the `/blog`around within the URL now redirects to the current page.