### PR TITLE
Update link to OAuth2.1 draft to reference version 12

### DIFF
--- a/public/2.1/index.php
+++ b/public/2.1/index.php
@@ -12,7 +12,7 @@ require('../../includes/_header.php');
 
     <h2 id="oauth-2-1">OAuth 2.1</h2>
 
-    <p><a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-11" class="rfc">datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-11</a></p>
+    <p><a href="https://datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12" class="rfc">datatracker.ietf.org/doc/html/draft-ietf-oauth-v2-1-12</a></p>
 
     <p>OAuth 2.1 is an in-progress effort to consolidate and simplify the most commonly used features of OAuth 2.0.</p>
 


### PR DESCRIPTION
Version 11 of the Oauth 2.1 spec was marked as "Expired & archived". It was replaced by active version 12.