### PR TITLE
Org name change to ruby-oauth

### DIFF
--- a/data/code/ruby.yml
+++ b/data/code/ruby.yml
@@ -1,7 +1,7 @@
 ---
 name: Ruby
 client_libraries:
-- <a href="https://gitlab.com/oauth-xx/oauth2">Oauth2 Ruby Gem - Wrapper for the OAuth 2.0 spec</a>
+- <a href="https://gitlab.com/ruby-oauth/oauth2">Oauth2 Ruby Gem - Wrapper for the OAuth 2.0 spec</a>
 - <a href="https://github.com/nov/rack-oauth2">Rack::OAuth2 - OAuth 2.0 Server & Client
   Library in Ruby.</a>
 server_libraries:


### PR DESCRIPTION
The old org name oauth-xx was intended to make it a suitable host for oauth libraries across multiple languages, but this never materialized.  Since the org only ever catered to ruby it made sense to rename to ruby-oauth.

More on the rename here: https://dev.to/galtzo/rename-oauth-xx-org-to-ruby-oauth-g44