### PR TITLE
Added free and open source OAuth mock server

### DIFF
--- a/public/code/index.php
+++ b/public/code/index.php
@@ -115,6 +115,7 @@ $languages = json_decode(file_get_contents(__DIR__.'/../../data/code/languages.j
     <ul>
       <li><a href="https://github.com/vouch/vouch-proxy">Vouch Proxy</a> - an nginx reverse proxy solution that adds OAuth/OpenID authentication</li>
       <li><a href="https://github.com/enterprise-oss/osso">Osso</a> - SAML to OAuth bridge</li>
+      <li><a href="https://oauth.kogiqa.com/">OAuth Mock Server</a> - A free and open-source OAuth mock server that simulates the biggest providers just by replacing the URL. Useful for E2E testing.</li>
     </ul>
 
     <?php /*


### PR DESCRIPTION
I've built an OAuth Mock Server designed to streamline testing. It acts as a drop-in URL replacement for major identity providers, allowing you to test your OAuth flows without needing actual user sign-ins. The server mimics the response formats of real providers perfectly. You can even mock specific user data by passing GET parameters in the initial request. This is an ideal tool for writing stable, reliable End-to-End (E2E) tests that include OAuth workflows. Check out the repository here: https://github.com/atagon-GmbH/oAuth-mock