### PR TITLE
fix: rfc number for private key jwt link

### DIFF
--- a/public/2/index.php
+++ b/public/2/index.php
@@ -103,7 +103,7 @@ require('../../includes/_header.php');
       <li><a href="/2/pushed-authorization-requests/">Pushed Authorization Requests (PAR)</a> - RFC 9126</li>
       <li><a href="/2/dpop/">Demonstration of Proof of Possession (DPoP)</a> - RFC 9449</li>
       <li><a href="/2/mtls/">Mutual TLS</a> - RFC 8705</li>
-      <li><a href="/private-key-jwt/">Private Key JWT</a> - (RFC 7521, RFC 7521, OpenID)</li>
+      <li><a href="/private-key-jwt/">Private Key JWT</a> - (RFC 7521, RFC 7523, OpenID)</li>
       <li><a href="/fapi/">FAPI</a></li>
     </ul>
 


### PR DESCRIPTION
The page https://oauth.net/2 has a wrong/duplicate RFC reference in the "High Security OAuth" section:
- `Private Key JWT - RFC 7521, RFC 7521, OpenID`

The second one should refer to `RFC 7523` as described in https://oauth.net/private-key-jwt.