### PR TITLE
Update OAuth 2.1 RFC references and terminology

### DIFF
--- a/public/2.1/index.php
+++ b/public/2.1/index.php
@@ -16,7 +16,7 @@ require('../../includes/_header.php');
 
     <p>OAuth 2.1 is an in-progress effort to consolidate and simplify the most commonly used features of OAuth 2.0.</p>
 
-    <p>Since the original publication of OAuth 2.0 (RFC 6749) in 2012, several new RFCs have been published that either add or remove functionality from the core spec, including <a href="/2/native-apps/">OAuth 2.0 for Native Apps</a> (RFC 8252), <a href="/2/pkce/">Proof Key for Code Exchange</a> (RFC 7636), <a href="/2/browser-based-apps/">OAuth for Browser-Based Apps</a>, and <a href="/2/oauth-best-practice/">OAuth 2.0 Security Best Current Practice</a>.</p>
+    <p>Since the original publication of OAuth 2.0 (RFC 6749) in 2012, several new RFCs and Internet-Drafts have been published that either add or remove functionality from the core spec. These include <a href="/2/native-apps/">OAuth 2.0 for Native Apps</a> (RFC 8252), <a href="/2/pkce/">Proof Key for Code Exchange</a> (RFC 7636), the active draft for <a href="/2/browser-based-apps/">OAuth for Browser-Based Apps</a>, and <a href="/2/oauth-best-practice/">OAuth 2.0 Security Best Current Practice</a> (RFC 9700).</p>
 
     <p>OAuth 2.1 consolidates the changes published in later specs to simplify the core document.</p>
 
@@ -28,7 +28,7 @@ require('../../includes/_header.php');
       <li>The Implicit grant (<code>response_type=token</code>) is omitted from this specification</li>
       <li>The Resource Owner Password Credentials grant is omitted from this specification</li>
       <li>Bearer token usage omits the use of bearer tokens in the query string of URIs</li>
-      <li>Refresh tokens for public clients must either be sender-constrained or one-time use</li>
+      <li>Refresh tokens for public clients must either be sender-constrained or rotated</li>
       <li>The definitions of public and confidential clients have been simplified to only refer to whether the client has credentials</li>
     </ul>
 


### PR DESCRIPTION
Hello! I noticed a few technical inaccuracies regarding the current state of the OAuth 2.1 specifications on this page and have updated them to reflect the latest IETF standards. 

Specific changes made:
1. **Clarified Draft vs. RFC status:** Rephrased the introductory paragraph to acknowledge that "OAuth for Browser-Based Apps" is still an active Internet-Draft, not a published RFC.
2. **Added Missing RFC Designation:** Added the official RFC number (RFC 9700) for the "OAuth 2.0 Security Best Current Practice" which was recently published.
3. **Terminology Alignment:** Updated the bullet point regarding refresh tokens from "one-time use" to "rotated" to perfectly align with the official phrasing (Refresh Token Rotation) used in the OAuth 2.1 draft.

Let me know if you need any adjustments!

Best,
Mohammad Aman