### PR TITLE
Add Authplane to OAuth providers, CIMD, cross-app access, and server libraries

### DIFF
--- a/data/code/go.yml
+++ b/data/code/go.yml
@@ -11,4 +11,8 @@ server_libraries:
   Gin Framework users who also want to use OAuth2'
 - '<a href="https://pkg.go.dev/github.com/AxisCommunications/go-dpop">go-dpop</a>: Golang DPoP client and server library'
 - '<a href="https://github.com/luikyv/go-oidc">go-oidc</a>: A configurable OpenID Provider built in Go'
+- '<a href="https://github.com/AuthPlane/authserver">Authplane authserver</a>: Self-hosted
+  OAuth 2.1 authorization server for the Model Context Protocol, shipped as a single Go binary'
+- '<a href="https://github.com/AuthPlane/go-sdk">Authplane go-sdk</a>: Protect MCP servers
+  and OAuth 2.1 resource servers, with net/http and MCP adapters'
 ...

--- a/data/code/go.yml
+++ b/data/code/go.yml
@@ -13,6 +13,7 @@ server_libraries:
 - '<a href="https://github.com/luikyv/go-oidc">go-oidc</a>: A configurable OpenID Provider built in Go'
 - '<a href="https://github.com/AuthPlane/authserver">Authplane authserver</a>: Self-hosted
   OAuth 2.1 authorization server for the Model Context Protocol, shipped as a single Go binary'
-- '<a href="https://github.com/AuthPlane/go-sdk">Authplane go-sdk</a>: Protect MCP servers
-  and OAuth 2.1 resource servers, with net/http and MCP adapters'
+- '<a href="https://github.com/AuthPlane/go-sdk">Authplane go-sdk</a>: JWT validation
+  and OAuth 2.1 protocol primitives for Go resource servers, with net/http, MCP, and
+  mark3labs/mcp-go adapters'
 ...

--- a/data/code/java.yml
+++ b/data/code/java.yml
@@ -24,4 +24,6 @@ server_libraries:
 - <a href="https://www.keycloak.org/">Keycloak</a>
 - <a href="https://connect2id.com/products/nimbus-oauth-openid-connect-sdk">Nimbus</a>
 - <a href="https://github.com/spring-projects/spring-authorization-server">Spring Authorization Server</a>
+- '<a href="https://github.com/AuthPlane/java-sdk">Authplane java-sdk</a>: Protect MCP
+  servers and OAuth 2.1 resource servers, with MCP and Spring Security adapters'
 ...

--- a/data/code/nodejs.yml
+++ b/data/code/nodejs.yml
@@ -20,4 +20,6 @@ server_libraries:
   Identity Provider system developed to support Firefox Marketplace and other services
 - '<a href="https://github.com/jaredhanson/oauth2orize">OAuth2orize: toolkit to implement
   OAuth2 Authorization Servers</a>'
+- '<a href="https://github.com/AuthPlane/ts-sdk">Authplane ts-sdk</a>: TypeScript SDK
+  to protect MCP servers and OAuth 2.1 resource servers, with MCP and FastMCP adapters'
 ...

--- a/data/code/nodejs.yml
+++ b/data/code/nodejs.yml
@@ -20,6 +20,7 @@ server_libraries:
   Identity Provider system developed to support Firefox Marketplace and other services
 - '<a href="https://github.com/jaredhanson/oauth2orize">OAuth2orize: toolkit to implement
   OAuth2 Authorization Servers</a>'
-- '<a href="https://github.com/AuthPlane/ts-sdk">Authplane ts-sdk</a>: TypeScript SDK
-  to protect MCP servers and OAuth 2.1 resource servers, with MCP and FastMCP adapters'
+- '<a href="https://github.com/AuthPlane/ts-sdk">Authplane ts-sdk</a>: JWT validation
+  and OAuth 2.1 protocol primitives for Node.js resource servers, with Hono, NestJS,
+  MCP, and FastMCP adapters'
 ...

--- a/data/code/python.yml
+++ b/data/code/python.yml
@@ -11,6 +11,8 @@ server_libraries:
   web framework for building APIs based on standard Python type hints.
   It includes support for OAuth2, integrated with OpenAPI
 - <a href="https://github.com/aliev/aioauth">aioauth</a> Asynchronous OAuth 2.0 library
+- '<a href="https://github.com/AuthPlane/python-sdk">Authplane python-sdk</a>: Protect
+  MCP servers and OAuth 2.1 resource servers, with MCP and FastMCP adapters'
 client_libraries:
 - <a href="http://authomatic.github.io/authomatic/">Authomatic</a>
 - <a href="https://python-social-auth.readthedocs.io/en/latest/"> Python Social Auth</a>

--- a/public/2/client-id-metadata-document/index.php
+++ b/public/2/client-id-metadata-document/index.php
@@ -28,6 +28,7 @@ require('../../../includes/_header.php');
         <ul>
           <li><a href="https://auth0.com/ai/docs/mcp/guides/registering-your-mcp-client-application">Auth0</a> (coming soon)</li>
           <li><a href="https://www.authlete.com/developers/cimd/">Authlete</a></li>
+          <li><a href="https://github.com/AuthPlane/authserver#standards--specifications">Authplane</a></li>
           <li><a href="https://www.descope.com/blog/post/cimd-support">Descope</a></li>
           <li><a href="https://docs.scalekit.com/authenticate/mcp/quickstart/">Scalekit</a></li>
           <li><a href="https://stytch.com/blog/oauth-client-id-metadata-mcp/">Stytch</a></li>

--- a/public/2/client-id-metadata-document/index.php
+++ b/public/2/client-id-metadata-document/index.php
@@ -28,7 +28,7 @@ require('../../../includes/_header.php');
         <ul>
           <li><a href="https://auth0.com/ai/docs/mcp/guides/registering-your-mcp-client-application">Auth0</a> (coming soon)</li>
           <li><a href="https://www.authlete.com/developers/cimd/">Authlete</a></li>
-          <li><a href="https://github.com/AuthPlane/authserver#standards--specifications">Authplane</a></li>
+          <li><a href="https://docs.authplane.ai/reference/rfc-compliance/#draft-ietf-oauth-client-id-metadata-document--cimd">Authplane</a></li>
           <li><a href="https://www.descope.com/blog/post/cimd-support">Descope</a></li>
           <li><a href="https://docs.scalekit.com/authenticate/mcp/quickstart/">Scalekit</a></li>
           <li><a href="https://stytch.com/blog/oauth-client-id-metadata-mcp/">Stytch</a></li>

--- a/public/code/index.php
+++ b/public/code/index.php
@@ -69,6 +69,7 @@ $languages = json_decode(file_get_contents(__DIR__.'/../../data/code/languages.j
     <span id="proxy-services-open-source"></span>
     <ul>
       <li><a href="https://goauthentik.io">Authentik</a></li>
+      <li><a href="https://github.com/AuthPlane/authserver">Authplane</a></li>
       <li><a href="https://github.com/curveball/a12n-server">a12n-server</a></li>
       <li><a href="https://github.com/casbin/casdoor">Casdoor</a></li>
       <li><a href="https://github.com/babelouest/glewlwyd">Glewlwyd</a></li>

--- a/public/cross-app-access/index.php
+++ b/public/cross-app-access/index.php
@@ -44,6 +44,7 @@ require('../../includes/_header.php');
           <li><a href="https://github.com/keycloak/keycloak/issues/43971">Keycloak</a> (in progress)</li>
           <li><a href="https://www.scalekit.com/blog/cross-app-access-agentic-auth-flows">Scalekit</a></li>
           <li><a href="https://docs.descope.com/agentic-identity-hub/enterprise-managed-authorization">Descope</a></li>
+          <li><a href="https://github.com/AuthPlane/authserver/blob/main/docs/guides/federation/enterprise-managed-auth-xaa.md">Authplane</a></li>
         </ul>
       </div>
       <div class="column">

--- a/public/cross-app-access/index.php
+++ b/public/cross-app-access/index.php
@@ -44,7 +44,7 @@ require('../../includes/_header.php');
           <li><a href="https://github.com/keycloak/keycloak/issues/43971">Keycloak</a> (in progress)</li>
           <li><a href="https://www.scalekit.com/blog/cross-app-access-agentic-auth-flows">Scalekit</a></li>
           <li><a href="https://docs.descope.com/agentic-identity-hub/enterprise-managed-authorization">Descope</a></li>
-          <li><a href="https://github.com/AuthPlane/authserver/blob/main/docs/guides/federation/enterprise-managed-auth-xaa.md">Authplane</a></li>
+          <li><a href="https://docs.authplane.ai/guides/xaa/">Authplane</a></li>
         </ul>
       </div>
       <div class="column">


### PR DESCRIPTION
Adds Authplane to the provider and implementation lists, plus the server-library lists for the four languages we ship SDKs in.

Authplane is a self-hosted OAuth 2.1 authorization server for MCP — a single Go binary, AGPL-3.0 ([AuthPlane/authserver](https://github.com/AuthPlane/authserver)) — with Apache-2.0 resource-server SDKs. Disclosure: I work on it, so this is a self-add; everything below is checkable against a running instance.

### `/code/` → OAuth Providers → Open Source

Authorization server is open source (AGPL-3.0). Metadata advertises `authorization_code`, `refresh_token`, `client_credentials`, token-exchange and jwt-bearer, with `code_challenge_methods_supported: ["S256"]` and no implicit or password grant.

### `/2/client-id-metadata-document/` → OAuth Servers

CIMD is implemented and on by default. The AS advertises `client_id_metadata_document_supported: true`, and a URL-valued `client_id` is fetched, validated, and auto-registered, with the document's `redirect_uris` enforced from that point on.

Reproducible with the published image:

```bash
docker run -p 9000:9000 -p 9001:9001 \
  -e AUTHPLANE_ADMIN_API_KEY="$(openssl rand -hex 32)" \
  -e AUTHPLANE_SESSION_SECRET="$(openssl rand -hex 32)" \
  authplane/authserver:latest serve

curl -s localhost:9000/.well-known/oauth-authorization-server | jq .client_id_metadata_document_supported
# true
```

### `/cross-app-access/` → Authorization Servers

XAA is implemented via the jwt-bearer grant (RFC 7523) on top of RFC 8693 token exchange; metadata reports `identity_assertion_supported: true` and lists `urn:ietf:params:oauth:grant-type:jwt-bearer`. It is opt-in — enabled with `xaa.enabled: true` — and the linked guide covers IdP trust setup, policy, ID-JAG exchange and the assertion format.

Happy to add a `(beta)`-style qualifier here if you'd prefer to distinguish opt-in support from on-by-default, or to drop this entry if you'd rather the list stay limited to the vendors already shipping it in production.

### `data/code/{go,python,java,nodejs}.yml` → Server Libraries

Resource-server SDKs — token validation and OAuth 2.1 protocol primitives, with framework adapters:

| | package | adapters |
|---|---|---|
| Go | [go-sdk](https://github.com/AuthPlane/go-sdk) | net/http, MCP, mark3labs/mcp-go |
| Python | [python-sdk](https://github.com/AuthPlane/python-sdk) | MCP, FastMCP |
| Java | [java-sdk](https://github.com/AuthPlane/java-sdk) | MCP, Spring Security |
| Node.js | [ts-sdk](https://github.com/AuthPlane/ts-sdk) | Hono, NestJS, MCP, FastMCP |

`authserver` itself is also listed under Go server libraries, alongside the other Go authorization servers there.

If you'd rather take the three list entries and leave the per-language additions out, I'm glad to trim this down — say the word and I'll push a revision.

---

Checked locally with PHP 7.4 (matching CI): `php -l` clean on all three changed PHP files, all four YAML files parse under Symfony YAML 5.2, and every touched page renders 200 with no notices. All added links return 200.

Content submitted here is released to the public domain per CONTRIBUTING.md.
